### PR TITLE
Update wildcards.js

### DIFF
--- a/addon/chrome/content/zotfile/wildcards.js
+++ b/addon/chrome/content/zotfile/wildcards.js
@@ -300,7 +300,7 @@ Zotero.ZotFile.Wildcards = new (function () {
       lastAuthor_lastf: authors[9],
       lastAuthor_initials: authors[10],
       collectionPaths: Zotero.ZotFile.Utils.getCollectionPathsOfItem(item),
-      citekey: Zotero.BetterBibTeX ? item.getField("citekey") : undefined,
+      citekey: Zotero.BetterBibTeX ? item.getField("citationKey") : undefined,
     };
     // define transform functions
     var itemtypeWildcard = function (item, map) {


### PR DESCRIPTION
The supported field name for the citekey is now citationKey. When Zotero adds its own, this will work regardless of whether BBT is installed or not.