### PR TITLE
only move not rename

### DIFF
--- a/addon/chrome/content/preferences.xhtml
+++ b/addon/chrome/content/preferences.xhtml
@@ -198,6 +198,10 @@
             <menuitem label="Always ask (non-disruptive)" value="2" />
             <menuitem label="Only ask if item has other atts" value="3" />
             <menuitem label="Always rename" value="4" />
+            <menuitem
+              label="Only move not rename if item has other atts"
+              value="5"
+            />
           </menupopup>
         </menulist>
       </hbox>

--- a/addon/chrome/content/preferences_zh-CN.xhtml
+++ b/addon/chrome/content/preferences_zh-CN.xhtml
@@ -185,6 +185,7 @@
             <menuitem label="总是询问（不中断）" value="2" />
             <menuitem label="仅在条目有其他附件时询问" value="3" />
             <menuitem label="总是重命名" value="4" />
+            <menuitem label="在条目有其他附件时只移动不重命名" value="5" />
           </menupopup>
         </menulist>
       </hbox>

--- a/addon/chrome/content/zotfile/notifier.js
+++ b/addon/chrome/content/zotfile/notifier.js
@@ -89,6 +89,11 @@ Zotero.ZotFile.notifierCallback = new (function () {
           txt: this.ZFgetString("renaming.clickMoveRename"),
           icons: [att.getImageSrc()],
         };
+        var move_message = {
+          lines: [att.attachmentFilename],
+          txt: this.ZFgetString("renaming.clickMove"),
+          icons: [att.getImageSrc()],
+        };
         // always ask user
         if (auto_rename == 2)
           this.infoWindow(
@@ -120,14 +125,35 @@ Zotero.ZotFile.notifierCallback = new (function () {
         }
         // always rename
         if (auto_rename == 4) on_confirm(att);
+        // Only move not rename
+        if (auto_rename == 5) {
+          console.log("auto_rename", 5);
+          var item_atts = Zotero.Items.get(item.getAttachments())
+            .filter(this.checkFileType)
+            .filter(
+              (att) =>
+                att.isImportedAttachment() ||
+                att.attachmentLinkMode ==
+                  Zotero.Attachments.LINK_MODE_LINKED_FILE,
+            );
+          console.log("item_atts", item_atts);
+          if (item_atts.length == 1) on_confirm(att);
+          if (item_atts.length > 1)
+            this.infoWindow(
+              this.ZFgetString("general.newAttachment"),
+              move_message,
+              duration,
+              () => on_confirm(att, false),
+            );
+        }
       }
     }.bind(Zotero.ZotFile),
   );
 
   var on_confirm = Zotero.Promise.coroutine(
-    function* (att) {
+    function* (att, rename = true) {
       // rename attachment
-      att = yield this.renameAttachment(att);
+      att = yield this.renameAttachment(att, undefined, rename);
       // user notification
       var progress_win = this.progressWindow(
         this.ZFgetString("general.newAttachmentRenamed"),

--- a/addon/chrome/content/zotfile/zotfile.properties
+++ b/addon/chrome/content/zotfile/zotfile.properties
@@ -37,6 +37,7 @@ watchFolder.newFile						=	ZotFile: New file in source folder
 watchFolder.clickRename					=	(click here to rename and attach this file to the currently selected Zotero item)
 watchFolder.noRegularItem				=	No regular Zotero item selected.
 
+renaming.clickMove                      =	(click here to move)
 renaming.clickMoveRename				=	(click here to move and rename)
 renaming.renamingFailed					=	Zotfile failed to automatically rename an attachment.
 renaming.renameAttach.confirm			=	Do you want to rename and attach/link the file '%S' to the currently selected Zotero item?

--- a/addon/chrome/content/zotfile/zotfile_zh-CN.properties
+++ b/addon/chrome/content/zotfile/zotfile_zh-CN.properties
@@ -37,6 +37,7 @@ watchFolder.newFile						=	ZotFile： 源文件夹中的新文件
 watchFolder.clickRename					=	（点此重命名并附加此文件到当前选中的Zotero条目）
 watchFolder.noRegularItem				=	未选中常规Zotero条目。
 
+renaming.clickMove                      =	（点此移动文件）
 renaming.clickMoveRename				=	（点此以移动并重命名）
 renaming.renamingFailed					=	Zotfile 无法自动重命名某个附件。
 renaming.renameAttach.confirm			=	您想要重命名并附加/链接文件'%S'到当前选中的Zotero条目吗？


### PR DESCRIPTION
1. Add a new option `Only move not rename if item has other atts` of `Automatically rename new attachments` preference item.
2. Keep "rename and move" when item has no atts.
3. Implement "only move not rename" when item has other atts.